### PR TITLE
Ignore rebase merges to avoid double (or more) counting of lines

### DIFF
--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -37,6 +37,11 @@ while [ "$REPOPATH" = "" ] ; do
 done
 cd $REPOPATH
 
+# Ignore rebase merges
+if [ -d $REPOPATH/.git/rebase-merge ] ; then
+	exit
+fi
+
 FORMAT="ZEITGIT $VERSION%nHOSTNAME $HOSTNAME%nPATH $REPOPATH%nORIGIN $ORIGIN%nBRANCH $BRANCH%nHASH %H%nTREEHASH %T%nPARENTHASH %P%nAUTHORNAME %aN%nAUTHOREMAIL %ae%nAUTHORDATE %at%nCOMMITERNAME %cN%nCOMMITEREMAIL %ce%nCOMMITERDATE %ct%nSUBJECT %s%nBODY %b"
 
 echo "Sending commit data to zeitgit collector at $EMAIL"


### PR DESCRIPTION
A giant rebase squash I did today sent a huge number of redundant commit lines to the collector.  This should prevent that by detecting the .git/rebase-merge directory, which is present during rebase merges. 

http://stackoverflow.com/questions/11367722/git-post-commit-skip-amend-and-rebase

I'm not sure of the wider design goals of Zeitgit, but leaving those lines out seems like a better representation of coding activity.  I suppose an alternate would be to send a commit message with 0 lines.
