### PR TITLE
Prevent the first two lines of the commit message being run together.

### DIFF
--- a/receiver/receiver.tcl
+++ b/receiver/receiver.tcl
@@ -171,7 +171,7 @@ while {[gets stdin line] >= 0} {
 		set cdata($key) "$value"
 		if {$key == "BODY"} {
 			set in_body 1
-			set cdata(BODY) "$value"
+			set cdata(BODY) "$value\n"
 		}
 	} elseif {[regexp { (.+) \| +(\d+) ([-+]+)} $line _ filename lines plusminus]} {
 		set in_body 0


### PR DESCRIPTION
The first two lines of the git commit comment are always run together, while all remaining lines continue to be newline-separated.  This puts in the missing newline.